### PR TITLE
Potential fix for code scanning alert no. 4: Incorrect conversion between integer types

### DIFF
--- a/main.go
+++ b/main.go
@@ -341,15 +341,17 @@ func getShardIndex(uuid string) int {
 	
 	lastBytes := cleaned[len(cleaned)-8:] // Last 4 bytes as hex string
 	
-	// Convert hex to uint32 for modulo operation
+	// Convert hex to int32 for modulo operation, with bounds check
 	hash, err := strconv.ParseUint(lastBytes, 16, 32)
 	if err != nil {
 		// Fallback for parse errors
 		return shardConfig.startIndex
 	}
-	
-	// Safe conversion: hash is guaranteed to fit in uint32, then convert to int
-	shardOffset := int(uint32(hash)) % shardConfig.shardCount
+	if hash > uint64(math.MaxInt32) {
+		// Fallback for out-of-bounds values
+		return shardConfig.startIndex
+	}
+	shardOffset := int(int32(hash)) % shardConfig.shardCount
 	return shardConfig.startIndex + shardOffset
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/mdastpak/otp-service/security/code-scanning/4](https://github.com/mdastpak/otp-service/security/code-scanning/4)

To fix the problem, we should ensure that the value parsed from the UUID substring is always safely converted to a signed integer type of known size, and that the modulo operation and return value are also of the correct type. The best way is to use `int32` for all intermediate and final values, since the parsed value is at most 32 bits. This avoids any risk of overflow or sign issues when converting from `uint32` to `int`. Specifically, after parsing with `strconv.ParseUint(..., 16, 32)`, we should check that the value does not exceed `math.MaxInt32` (2147483647) before converting to `int32`, or use `strconv.ParseInt(..., 16, 32)` directly to parse as a signed 32-bit integer. Since UUIDs are random, negative values are not expected, so we can safely use `strconv.ParseUint` and check for `hash <= math.MaxInt32`. The modulo operation should also be performed with `int32` values, and the final result returned as `int`.

**Required changes:**
- In `getShardIndex`, after parsing `hash`, check that `hash <= math.MaxInt32`.
- If the check passes, convert `hash` to `int32` and use it for the modulo operation.
- If the check fails, fall back to `shardConfig.startIndex`.
- Import `math` if not already imported (already present).
- No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
